### PR TITLE
v2.3.0: Добавление FieldModel и ListModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [+] ListModel
 - [+] FieldModel
+- [+] В конструктор PollingModel добавлен необязательный параметр isImmediate
 
 ## v2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v2.2.0
 
-- [+] модели для работы со списками: ApiListModel и MockApiListModel
+- [+] модели для работы со списками: ListModel, ApiListModel и MockApiListModel
+- [+] FieldModel
 - [+] PollingModel
 - [+] BlurAndFocusHandlerModel
 - [+] модели для таймеров: BaseTimerModel, TimerModel, FixedTimerModel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
+## v2.3.0
+
+- [+] ListModel
+- [+] FieldModel
+
 ## v2.2.0
 
-- [+] модели для работы со списками: ListModel, ApiListModel и MockApiListModel
-- [+] FieldModel
+- [+] модели для работы со списками: ApiListModel и MockApiListModel
 - [+] PollingModel
 - [+] BlurAndFocusHandlerModel
 - [+] модели для таймеров: BaseTimerModel, TimerModel, FixedTimerModel

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ export default class MySubStore extends SubStoreModel<RootStore> {
 
 Модель таймера, который отсчитывает время до заданной даты в секундах и по окончании вызывает callback-функцию.
 
+### FieldModel
+
+Модель для изменяемых полей классов.
+
 ## Сторы
 
 ### RootStore

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ export default class MySubStore extends SubStoreModel<RootStore> {
 
 Модель для изменяемых полей классов.
 
+### ListModel
+
+Модель для работы со списками однотипных данных.
+
 ## Сторы
 
 ### RootStore

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ktsstudio/mediaproject-stores",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "author": "KTS Studio",
   "license": "MIT",
   "description": "Package with basic MobX stores for mediaprojects",

--- a/src/models/FieldModel/FieldModel.ts
+++ b/src/models/FieldModel/FieldModel.ts
@@ -2,7 +2,7 @@ import { action, computed, makeObservable, observable } from 'mobx';
 
 import { IField } from './types';
 
-export default class FieldModel<T = string> implements IField<T> {
+class FieldModel<T = string> implements IField<T> {
   private _value: T;
   private _initialValue: T;
 
@@ -32,3 +32,5 @@ export default class FieldModel<T = string> implements IField<T> {
     this._value = this._initialValue;
   }
 }
+
+export default FieldModel;

--- a/src/models/FieldModel/FieldModel.ts
+++ b/src/models/FieldModel/FieldModel.ts
@@ -1,0 +1,34 @@
+import { action, computed, makeObservable, observable } from 'mobx';
+
+import { IField } from './types';
+
+export default class FieldModel<T = string> implements IField<T> {
+  private _value: T;
+  private _initialValue: T;
+
+  constructor(value: T) {
+    this._value = value;
+    this._initialValue = value;
+
+    makeObservable<FieldModel<T>, '_value'>(this, {
+      _value: observable.ref,
+
+      value: computed,
+
+      changeValue: action.bound,
+      reset: action.bound,
+    });
+  }
+
+  get value(): T {
+    return this._value;
+  }
+
+  changeValue(value: T): void {
+    this._value = value;
+  }
+
+  reset(): void {
+    this._value = this._initialValue;
+  }
+}

--- a/src/models/FieldModel/FieldModel.ts
+++ b/src/models/FieldModel/FieldModel.ts
@@ -8,7 +8,8 @@ class FieldModel<T = string> implements IField<T> {
 
   constructor(value: T, config?: { initialValue: T }) {
     this._value = value;
-    this._initialValue = config?.initialValue ?? value;
+    this._initialValue =
+      config?.initialValue === undefined ? value : config.initialValue;
 
     makeObservable<FieldModel<T>, '_value'>(this, {
       _value: observable.ref,

--- a/src/models/FieldModel/FieldModel.ts
+++ b/src/models/FieldModel/FieldModel.ts
@@ -4,11 +4,11 @@ import { IField } from './types';
 
 class FieldModel<T = string> implements IField<T> {
   private _value: T;
-  private _initialValue: T;
+  private readonly _initialValue: T;
 
-  constructor(value: T) {
+  constructor(value: T, config?: { initialValue: T }) {
     this._value = value;
-    this._initialValue = value;
+    this._initialValue = config?.initialValue ?? value;
 
     makeObservable<FieldModel<T>, '_value'>(this, {
       _value: observable.ref,
@@ -24,8 +24,10 @@ class FieldModel<T = string> implements IField<T> {
     return this._value;
   }
 
-  changeValue(value: T): void {
+  changeValue<I extends T>(value: I): I {
     this._value = value;
+
+    return value;
   }
 
   reset(): void {

--- a/src/models/FieldModel/index.ts
+++ b/src/models/FieldModel/index.ts
@@ -1,0 +1,3 @@
+export { default as FieldModel } from './FieldModel';
+
+export * from './types';

--- a/src/models/FieldModel/types.ts
+++ b/src/models/FieldModel/types.ts
@@ -1,0 +1,6 @@
+export interface IField<T = string> {
+  get value(): T;
+
+  changeValue(value: T): void;
+  reset(): void;
+}

--- a/src/models/PollingModel/PollingModel.ts
+++ b/src/models/PollingModel/PollingModel.ts
@@ -3,15 +3,26 @@ export default class PollingModel {
 
   private readonly _pollingFunc: VoidFunction;
 
+  private readonly _isImmediate: boolean;
+
   private _pollingInterval: NodeJS.Timeout | null = null;
 
-  constructor(intervalTime: number, pollingFunc: VoidFunction) {
+  constructor(
+    intervalTime: number,
+    pollingFunc: VoidFunction,
+    isImmediate?: boolean
+  ) {
     this._intervalTime = intervalTime;
     this._pollingFunc = pollingFunc;
+    this._isImmediate = isImmediate ?? false;
   }
 
   startPolling = (): void => {
     this.stopPolling();
+
+    if (this._isImmediate) {
+      this._pollingFunc();
+    }
 
     this._pollingInterval = setInterval(this._pollingFunc, this._intervalTime);
   };

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -9,3 +9,5 @@ export * from './timers';
 export * from './BlurAndFocusHandlerModel';
 
 export * from './PollingModel';
+
+export * from './FieldModel';

--- a/src/models/lists/ListModel/ListModel.ts
+++ b/src/models/lists/ListModel/ListModel.ts
@@ -90,7 +90,10 @@ class ListModel<T, K extends string | number = string> implements IList<T, K> {
     return this._entities[key];
   }
 
-  /** Получает элемент типа T по его индексу */
+  /**
+   * Получает элемент типа T по его индексу.
+   * Если элемент не найден, возвращает null.
+   */
   getEntityByIndex(index: number): T | null {
     const id = this.keys[index];
 

--- a/src/models/lists/ListModel/ListModel.ts
+++ b/src/models/lists/ListModel/ListModel.ts
@@ -1,0 +1,194 @@
+import { action, computed, makeObservable, observable } from 'mobx';
+
+import { IList } from './types';
+
+type ListModelPrivateFields = '_keys' | '_entities';
+
+/**
+ * ListModel<T, C extends string | number = string>
+ *
+ * @implements {IList<T, K>}
+ * T - тип данных элемента исходного списка.
+ * K - типа данных идентификатора (ключа) каждого элемента.
+ *
+ * @param {T[]} items Исходный список элементов типа T
+ * @param {(item: T) => K} getKeyForItem Функция, принимающая элемент списка, и возвращающая его идентификатор
+ */
+class ListModel<T, K extends string | number = string> implements IList<T, K> {
+  private _keys: K[] = [];
+  private _entities: Record<K, T> = {} as Record<K, T>;
+
+  constructor(items: T[], getKeyForItem: (item: T) => K) {
+    this._normalize(items, getKeyForItem);
+
+    makeObservable<ListModel<T, K>, ListModelPrivateFields>(this, {
+      _keys: observable,
+      _entities: observable,
+
+      keys: computed,
+      entities: computed,
+      length: computed,
+      items: computed,
+
+      addEntity: action,
+      addEntities: action,
+      removeEntity: action,
+      removeEntities: action,
+      toStart: action,
+      reset: action,
+    });
+  }
+
+  private _normalize(items: T[], getKeyForItem: (item: T) => K) {
+    items.forEach((item) => {
+      const key = getKeyForItem(item);
+
+      this._keys.push(key);
+      this._entities[key] = item;
+    });
+  }
+
+  /** Возвращает список ключей (идентификаторов) */
+  get keys(): K[] {
+    return this._keys;
+  }
+
+  /**
+   * Возвращает объект, в котором ключ типа К является идентификатором
+   * и значение типа Т является элементом исходного списка
+   */
+  get entities(): Record<K, T> {
+    return this._entities;
+  }
+
+  /** Возвращает список элементов типа T */
+  get items(): T[] {
+    return this._keys.reduce((acc: T[], id: K) => {
+      const item = this._entities[id];
+
+      return item ? [...acc, item] : acc;
+    }, []);
+  }
+
+  /** Возвращает количество элементов */
+  get length(): number {
+    return this.items.length;
+  }
+
+  /** Получает элемент типа T по его идентификатору (ключу) типа K */
+  getEntityByKey = (key: K): T => {
+    return this._entities[key];
+  };
+
+  /** Получает элемент типа T по его индексу */
+  getEntityByIndex = (index: number): T => {
+    const id = this.keys[index];
+
+    return this.getEntityByKey(id);
+  };
+
+  /**
+   * По ключу типа K получает объект, содержащий элемент типа T и его индекс.
+   * Если такого ключа нет, возвращает null.
+   */
+  getEntityAndIndex = (key: K): { item: T; index: number } | null => {
+    const index = this.keys.indexOf(key);
+
+    if (index === -1) {
+      return null;
+    }
+
+    const item = this.items[index];
+
+    return item ? { item, index } : null;
+  };
+
+  /**
+   * Добавляет новую запись
+   * @param {boolean} isToStart Помещать новую запись в начало списка?
+   */
+  addEntity = ({
+    entity,
+    key,
+    isToStart = false,
+  }: {
+    entity: T;
+    key: K;
+    isToStart?: boolean;
+  }): void => {
+    this._entities[key] = entity;
+
+    if (isToStart) {
+      this._keys.unshift(key);
+    } else {
+      this._keys.push(key);
+    }
+  };
+
+  /**
+   * Добавляет несколько новых записей
+   * @param {Object} param
+   * @param {boolean} param.isInitial Затереть текущие записи новыми?
+   * @param {boolean} param.isToStart Поместить новые записи в начало?
+   */
+  addEntities = ({
+    entities,
+    keys,
+    isInitial,
+    isToStart,
+  }: {
+    entities: Record<K, T>;
+    keys: K[];
+    isInitial: boolean;
+    isToStart?: boolean;
+  }): void => {
+    if (isInitial) {
+      this._entities = entities;
+      this._keys = keys;
+
+      return;
+    }
+
+    this._entities = {
+      ...this._entities,
+      ...entities,
+    };
+
+    if (isToStart) {
+      this._keys.unshift(...keys);
+    } else {
+      this._keys.push(...keys);
+    }
+  };
+
+  /** Удаляет запись с ключом keyParam */
+  removeEntity = (keyParam: K): void => {
+    this._keys = this._keys.filter((key) => key !== keyParam);
+    delete this._entities[keyParam];
+  };
+
+  /** Удаляет несколько записей, которые имеют ключи keys */
+  removeEntities = (keys: K[]): void => {
+    keys.forEach(this.removeEntity);
+  };
+
+  /** Перемещает запись с ключом key в начало списка */
+  toStart = (key: K): void => {
+    const foundIndex = this.keys.indexOf(key);
+
+    if (foundIndex === -1) {
+      return;
+    }
+
+    this.keys.splice(foundIndex, 1);
+    this.keys.splice(0, 0, key);
+  };
+
+  /** Очищает модель */
+  reset = (): void => {
+    this._keys = [];
+    this._entities = {} as Record<K, T>;
+  };
+}
+
+export default ListModel;

--- a/src/models/lists/ListModel/index.ts
+++ b/src/models/lists/ListModel/index.ts
@@ -1,0 +1,3 @@
+export { default as ListModel } from './ListModel';
+
+export * from './types';

--- a/src/models/lists/ListModel/types.ts
+++ b/src/models/lists/ListModel/types.ts
@@ -1,0 +1,29 @@
+export interface IList<T, K extends string | number | symbol = string> {
+  get keys(): K[];
+  get entities(): Record<K, T>;
+  get items(): Array<T>;
+  get length(): number;
+
+  getEntityByKey(key: K): T | null;
+  getEntityByIndex(index: number): T;
+  getEntityAndIndex(key: K): { item: T; index: number } | null;
+
+  addEntity(params: { entity: T; key: K; isToStart?: boolean }): void;
+  addEntities({
+    entities,
+    keys,
+    isInitial,
+    isToStart,
+  }: {
+    entities: Record<K, T>;
+    keys: K[];
+    isInitial: boolean;
+    isToStart?: boolean;
+  }): void;
+
+  removeEntity(param: K): void;
+  removeEntities(params: K[]): void;
+
+  toStart(key: K): void;
+  reset(): void;
+}

--- a/src/models/lists/ListModel/types.ts
+++ b/src/models/lists/ListModel/types.ts
@@ -1,11 +1,11 @@
-export interface IList<T, K extends string | number | symbol = string> {
+export interface IList<T, K extends string | number = string> {
   get keys(): K[];
   get entities(): Record<K, T>;
   get items(): Array<T>;
   get length(): number;
 
   getEntityByKey(key: K): T | null;
-  getEntityByIndex(index: number): T;
+  getEntityByIndex(index: number): T | null;
   getEntityAndIndex(key: K): { item: T; index: number } | null;
 
   addEntity(params: { entity: T; isToStart?: boolean }): void;

--- a/src/models/lists/ListModel/types.ts
+++ b/src/models/lists/ListModel/types.ts
@@ -8,16 +8,14 @@ export interface IList<T, K extends string | number | symbol = string> {
   getEntityByIndex(index: number): T;
   getEntityAndIndex(key: K): { item: T; index: number } | null;
 
-  addEntity(params: { entity: T; key: K; isToStart?: boolean }): void;
+  addEntity(params: { entity: T; isToStart?: boolean }): void;
   addEntities({
     entities,
-    keys,
     isInitial,
     isToStart,
   }: {
-    entities: Record<K, T>;
-    keys: K[];
-    isInitial: boolean;
+    entities: T[];
+    isInitial?: boolean;
     isToStart?: boolean;
   }): void;
 

--- a/src/models/lists/index.ts
+++ b/src/models/lists/index.ts
@@ -1,3 +1,5 @@
 export * from './ApiListModel';
 
 export * from './MockApiListModel';
+
+export * from './ListModel';

--- a/yarn.lock
+++ b/yarn.lock
@@ -176,10 +176,10 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
   integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
 
-"@types/react@~17.0.0":
-  version "17.0.38"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.38.tgz#f24249fefd89357d5fa71f739a686b8d7c7202bd"
-  integrity sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==
+"@types/react@>=17":
+  version "18.2.38"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.38.tgz#3605ca41d3daff2c434e0b98d79a2469d4c2dd52"
+  integrity sha512-cBBXHzuPtQK6wNthuVMV6IjHAFkdl/FOPFIlkd81/Cd1+IqkHu/A+w4g43kaQQoYHik/ruaQBDL72HyCy1vuMw==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -1687,7 +1687,7 @@ react-is@^16.13.1, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react@>=17.0.0:
+react@>=17:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
   integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==


### PR DESCRIPTION
Задача:
- [SPECIAL-13089](https://youtrack.kts.studio/issue/SPECIAL-13089) [mediaproject-stores] Добавить новые модели

Добавлены модели:
- `FieldModel` для работы с изменяемыми полями ([пример](https://gitlab.team.ktsstudio.ru/n-plus-one/animal-lives-front/-/blob/main/src/store/models/FieldModel/FieldModel.ts)).
- `ListModel` для работы со списками однотипных элементов ([пример](https://gitlab.team.ktsstudio.ru/n-plus-one/restoration-of-history-front/-/blob/main/src/store/models/ListModel/ListModel.ts)).

В `ListModel` добавлен метод `_normalize()`, чтобы приводить исходный список к объекту внутри модели, а не снаружи.


